### PR TITLE
[#09] feat: broker execution adapter (Zerodha Kite Connect)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,11 @@ state = {
 
 ## What NOT To Do
 
+- **Don't subscribe to `NIFTY 50` (spot) in `collect_ticks.py`** — this was a 2026-04-08 bug that corrupted every macro feature. Spot and futures prices differ by ~50pt, and when both were stored under `symbol='NIFTY-I'` in `tick_data`, the resulting minute candles had fake ~40pt high-low ranges that poisoned RSI/ATR/Bollinger/MACD and silently destroyed the macro_model retrains. Only subscribe to `NIFTY-I` futures. The `on_tick()` handler has a defensive drop for any leaking spot symbol.
+- **Don't use `expiries[-1]` as a fallback in `get_nearest_expiry()`** — this was the 2026-04-08 bug that had the live collector subscribing to *yesterday's* expired contracts every morning. The only correct source for future expiries is TrueData REST `getSymbolExpiryList` (cached 1h). DB-derived expiries are only correct for historical backtests on past dates. `get_nearest_expiry()` now splits these two paths.
+- **Don't apply entry gates uniformly across strategies** — the 2026-04-08 first-pass fix broke MEDIUM from ₹+51k → ₹+37k because the previous-bar confirmation gate and micro-momentum gate were structurally wrong for reversal strategies (`bearish_momentum`, `mean_reversion`). A reversal signal *should* fire against recent momentum by design. Both gates now have a `CONTINUATION_STRATEGIES = {"vwap_momentum_breakout"}` check. If you add a new strategy, decide whether it's continuation or reversal before wiring gates.
+- **Don't use tick-COUNT windows for option-premium confirmation** — "last 10 ticks" can span 20 minutes on illiquid strikes and produce meaningless slopes. The Fix D gate uses a 30-SECOND time window and fails open if <8 ticks exist in that window.
+- **Don't check SL against `min(p_low_bid, self.sl)` after ratcheting SL within the same bar** — this was the 2026-04-08 trailing-stop giveback bug. Bars that spiked +30% then crashed to -5% activated trailing AND filled at -5% instead of at the trailing lock. Check SL against PRIOR sl, ratchet only after no exit, fill at `prior_sl` (not bar low).
 - **Don't use `incremental_train.py --days N` where N > 3** — safety guard rejects it; use `main.py train` for full retrains
 - **Don't retrain macro/micro models without a stable backtest baseline** — retraining changes XGBoost weights → different entry bars → RL_EXIT may stop firing → P&L collapses. Always restore from `backups/` if results degrade.
 - **Don't use `generate_macro_labels(threshold > 0.002, forward_periods > 20)`** — higher thresholds yield <5% positive rate → model outputs near-0 for all bars → directional_prob for PUT ≈ 1.0 constant → no signal filtering. Keep `threshold=0.001, forward_periods=15`.
@@ -388,10 +393,18 @@ MODEL_DIR=models/saved
 
 - **Market hours**: 9:15–15:30 IST weekdays. `_is_market_hours()` guards scanner and collector startup
 - **NIFTY lot size**: 65 units (1 lot = 65 shares)
-- **NIFTY weekly expiry**: Tuesdays (confirmed from symbol_master in DB)
+- **NIFTY weekly expiry**: Tuesdays by default, but individual weeks can be holiday-shifted (e.g. Apr 14 2026 → Apr 13 because Apr 14 is a national holiday). Never hard-code a weekday; always fetch from TrueData REST `getSymbolExpiryList`.
 - **ATM strike gap**: 50 points for NIFTY
 - **TickCollector buffer**: flushes to `tick_data` every 200 ticks
 - **Candle aggregation**: done by `collect_ticks.py` in-memory per minute, written via `upsert_candles()`
+- **Tick gap backfill**: `_backfill_ticks_if_stale()` runs every scan cycle during market hours, detects leading/internal/trailing gaps in today's `tick_data`, and fills them via TrueData REST `getticks`. Throttled to once per 60s.
 - **Model backups**: stored in `models/saved/backups/` with timestamp suffix before each retrain
 - **Logs**: `logs/tick_collector_YYYYMMDD.log` (one file per day), `logs/trading.log`
 - **Backtest results**: `backtest_results/*.json` and `*.csv`
+- **Backtest mode**: `scripts/tick_replay_backtest.py` uses tick-level option premium data via `load_option_premiums_for_day()`. The function detects tick availability and falls back to minute candles only when <50 ticks exist. Exit logic (SL/target/trailing) walks individual ticks within each minute when in tick mode.
+- **Entry gates** (in order, all in `backend/app.py:scan_market()` and `scripts/tick_replay_backtest.py`):
+    1. Score threshold (≥ 0.75, strategy-specific raises: mean_reversion 0.80, vwap 0.78)
+    2. Previous-bar direction confirmation — **continuation strategies only**
+    3. Micro-momentum confirmation (tick_momentum) — **continuation strategies only**
+    4. Option-premium confirmation (Fix D) — **all strategies**, 30s window, 0.8% drop threshold
+- **Intra-trade regime exit**: `_tick_monitor_loop` has three tiers — 0.10% adverse NIFTY move (log), 0.20% (tighten SL to entry+2%), 0.30% (HARD EXIT if option is underwater). Check interval 10s.

--- a/backend/app.py
+++ b/backend/app.py
@@ -2941,8 +2941,105 @@ def api_option_ticks():
     return jsonify({"data": df.to_dict(orient="records"), "source": source})
 
 
+# ── Broker Execution API ────────────────────────────────────────────────────
+
+from broker.order_manager import OrderManager
+
+order_manager = OrderManager()
+
+
+@app.route("/api/broker/status")
+def api_broker_status():
+    """Return broker connection state, positions, daily P&L."""
+    return jsonify(order_manager.to_dict())
+
+
+@app.route("/api/broker/connect", methods=["POST"])
+def api_broker_connect():
+    """Authenticate with the configured broker."""
+    ok = order_manager.connect()
+    return jsonify({"connected": ok, "broker": order_manager.adapter.broker_name})
+
+
+@app.route("/api/broker/auth/login_url")
+def api_broker_login_url():
+    """Get the OAuth login URL for Zerodha (step 1 of auth flow)."""
+    from broker.zerodha_adapter import ZerodhaAdapter
+    if isinstance(order_manager.adapter, ZerodhaAdapter):
+        url = order_manager.adapter.generate_login_url()
+        return jsonify({"login_url": url})
+    return jsonify({"login_url": "", "message": "Not using Zerodha adapter"})
+
+
+@app.route("/api/broker/auth/callback", methods=["POST"])
+def api_broker_auth_callback():
+    """Complete OAuth flow with request_token (step 3)."""
+    from broker.zerodha_adapter import ZerodhaAdapter
+    body = request.get_json(force=True) if request.is_json else {}
+    token = body.get("request_token", "")
+    if not token:
+        return jsonify({"error": "request_token required"}), 400
+    if isinstance(order_manager.adapter, ZerodhaAdapter):
+        ok = order_manager.adapter.complete_auth(token)
+        return jsonify({"authenticated": ok})
+    return jsonify({"error": "Not using Zerodha adapter"}), 400
+
+
+@app.route("/api/broker/kill", methods=["POST"])
+def api_broker_kill():
+    """EMERGENCY: Kill switch — close all positions, halt trading."""
+    result = order_manager.kill_switch()
+    return jsonify(result)
+
+
+@app.route("/api/broker/resume", methods=["POST"])
+def api_broker_resume():
+    """Resume trading after a halt."""
+    result = order_manager.resume()
+    return jsonify(result)
+
+
+@app.route("/api/broker/reconcile")
+def api_broker_reconcile():
+    """Compare internal positions vs broker positions."""
+    return jsonify(order_manager.reconcile())
+
+
+@app.route("/api/broker/confirm", methods=["POST"])
+def api_broker_confirm_signal():
+    """Confirm a pending signal (manual confirmation mode)."""
+    body = request.get_json(force=True) if request.is_json else {}
+    index = body.get("index", 0)
+    result = order_manager.confirm_signal(index)
+    return jsonify(result)
+
+
+@app.route("/api/broker/reject", methods=["POST"])
+def api_broker_reject_signal():
+    """Reject a pending signal (manual confirmation mode)."""
+    body = request.get_json(force=True) if request.is_json else {}
+    index = body.get("index", 0)
+    result = order_manager.reject_signal(index)
+    return jsonify(result)
+
+
+@app.route("/api/broker/exit", methods=["POST"])
+def api_broker_exit():
+    """Manually exit a specific position by order_id."""
+    body = request.get_json(force=True) if request.is_json else {}
+    order_id = body.get("order_id", "")
+    price = float(body.get("price", 0))
+    if not order_id:
+        return jsonify({"error": "order_id required"}), 400
+    result = order_manager.exit_position(order_id, price=price, reason="MANUAL_EXIT")
+    return jsonify(result)
+
+
 if __name__ == "__main__":
     initialize()
+
+    # Connect broker adapter (paper by default)
+    order_manager.connect()
 
     # Start background scanner
     scanner_thread = threading.Thread(target=background_scanner, daemon=True)
@@ -2955,11 +3052,15 @@ if __name__ == "__main__":
     _default_port = 5050
     port = int(os.environ.get("PORT") or _default_port)
 
+    trade_mode = os.getenv("TRADE_MODE", "paper")
     print("\n" + "=" * 50)
-    print("  AI Trader Paper Trading Dashboard")
-    print(f"  Flask API: http://localhost:{port}")
+    print("  AI Trader Dashboard")
+    print(f"  Mode:       {trade_mode.upper()}")
+    print(f"  Broker:     {order_manager.adapter.broker_name}")
+    print(f"  Flask API:  http://localhost:{port}")
     print("  Next.js UI: http://localhost:3000")
     print(f"  SSE Stream: http://localhost:{port}/api/stream")
+    print(f"  Kill switch: POST http://localhost:{port}/api/broker/kill")
     print("  Press Ctrl+C to stop")
     print("=" * 50 + "\n")
 

--- a/broker/__init__.py
+++ b/broker/__init__.py
@@ -1,0 +1,15 @@
+"""
+Broker Execution Adapters
+─────────────────────────
+Broker-agnostic execution layer for the AI Trader signal pipeline.
+
+Architecture:
+  scan_market() → OrderManager → BrokerAdapter.buy/sell/modify_sl
+
+Adapters:
+  PaperAdapter    — simulated trades (default, current behavior)
+  ZerodhaAdapter  — Kite Connect API (real money)
+
+Config:
+  TRADE_MODE env var: "paper" (default) | "zerodha"
+"""

--- a/broker/base_adapter.py
+++ b/broker/base_adapter.py
@@ -1,0 +1,222 @@
+"""
+Abstract Broker Adapter
+───────────────────────
+Defines the interface that all broker implementations must follow.
+Adding a new broker = implementing this interface + registering in __init__.py.
+
+Every method that touches real money has explicit safety documentation.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class OrderSide(str, Enum):
+    BUY = "BUY"
+    SELL = "SELL"
+
+
+class OrderType(str, Enum):
+    MARKET = "MARKET"
+    LIMIT = "LIMIT"
+    SL = "SL"           # stop-loss order
+    SL_MARKET = "SL-M"  # stop-loss market
+
+
+class OrderStatus(str, Enum):
+    PENDING = "PENDING"       # submitted but not yet confirmed
+    OPEN = "OPEN"             # confirmed by exchange, waiting to fill
+    COMPLETE = "COMPLETE"     # fully filled
+    CANCELLED = "CANCELLED"
+    REJECTED = "REJECTED"
+    ERROR = "ERROR"
+
+
+class ProductType(str, Enum):
+    """Zerodha/NSE product types."""
+    NRML = "NRML"    # Normal (carry-forward) — for options this is standard
+    MIS = "MIS"      # Margin Intraday — auto-squared-off at 15:20 IST
+    CNC = "CNC"      # Cash and Carry (equity only)
+
+
+@dataclass
+class OrderRequest:
+    """What we send TO the broker."""
+    symbol: str                       # e.g. "NIFTY26041323800PE"
+    exchange: str = "NFO"             # NFO for F&O, NSE for equity
+    side: OrderSide = OrderSide.BUY
+    order_type: OrderType = OrderType.MARKET
+    product: ProductType = ProductType.MIS  # intraday by default
+    quantity: int = 0                 # in units (not lots)
+    price: float = 0.0               # limit price (ignored for MARKET)
+    trigger_price: float = 0.0       # for SL/SL-M orders
+    tag: str = ""                    # free-text tag for reconciliation
+
+
+@dataclass
+class OrderResponse:
+    """What the broker returns AFTER placing an order."""
+    order_id: str = ""
+    status: OrderStatus = OrderStatus.PENDING
+    filled_quantity: int = 0
+    average_price: float = 0.0
+    message: str = ""
+    timestamp: datetime = field(default_factory=datetime.now)
+    raw: dict = field(default_factory=dict)  # broker-specific raw response
+
+
+@dataclass
+class Position:
+    """An open or closed position as reported by the broker."""
+    symbol: str = ""
+    exchange: str = "NFO"
+    quantity: int = 0          # positive = long, negative = short
+    average_price: float = 0.0
+    last_price: float = 0.0
+    pnl: float = 0.0
+    product: ProductType = ProductType.MIS
+    order_id: str = ""         # entry order ID
+
+
+class BrokerAdapter(ABC):
+    """
+    Abstract base class for all broker integrations.
+
+    Subclasses must implement every @abstractmethod. The OrderManager
+    calls these methods — it never touches broker-specific APIs directly.
+
+    Safety contract:
+      - authenticate() must be called before any order method
+      - buy/sell always return OrderResponse (never raise on order rejection)
+      - kill_switch() MUST close all positions unconditionally
+      - is_connected property must reflect real connectivity state
+    """
+
+    # ── Authentication ────────────────────────────────────────────────
+
+    @abstractmethod
+    def authenticate(self) -> bool:
+        """
+        Establish a session with the broker.
+
+        For Zerodha: complete the OAuth2 flow (redirect URL → access_token).
+        For Paper: always returns True.
+
+        Returns True if authenticated, False otherwise.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """True if the adapter has a valid, authenticated session."""
+        ...
+
+    @property
+    @abstractmethod
+    def broker_name(self) -> str:
+        """Human-readable broker name for display (e.g. 'Zerodha', 'Paper')."""
+        ...
+
+    # ── Order Placement ───────────────────────────────────────────────
+
+    @abstractmethod
+    def place_order(self, request: OrderRequest) -> OrderResponse:
+        """
+        Place a single order. Returns OrderResponse with order_id and status.
+
+        This is the raw order placement — callers should use OrderManager's
+        buy() / sell() wrappers which add logging, safety checks, and
+        position tracking.
+
+        Must NOT raise on order rejection — return OrderResponse with
+        status=REJECTED and the rejection message.
+        """
+        ...
+
+    @abstractmethod
+    def modify_order(
+        self,
+        order_id: str,
+        quantity: Optional[int] = None,
+        price: Optional[float] = None,
+        trigger_price: Optional[float] = None,
+        order_type: Optional[OrderType] = None,
+    ) -> OrderResponse:
+        """Modify an existing open order (e.g. update SL trigger price)."""
+        ...
+
+    @abstractmethod
+    def cancel_order(self, order_id: str) -> OrderResponse:
+        """Cancel an existing open order."""
+        ...
+
+    # ── Position & Order Queries ──────────────────────────────────────
+
+    @abstractmethod
+    def get_positions(self) -> list[Position]:
+        """Return all open positions from the broker."""
+        ...
+
+    @abstractmethod
+    def get_order_status(self, order_id: str) -> OrderResponse:
+        """Get the current status of a specific order."""
+        ...
+
+    @abstractmethod
+    def get_orders_today(self) -> list[OrderResponse]:
+        """Return all orders placed today (for reconciliation)."""
+        ...
+
+    # ── Safety ────────────────────────────────────────────────────────
+
+    @abstractmethod
+    def kill_switch(self) -> list[OrderResponse]:
+        """
+        EMERGENCY: Close ALL open positions at market price immediately.
+
+        This is the nuclear option. It:
+          1. Cancels all pending/open orders
+          2. Places market SELL orders for all long positions
+          3. Returns list of exit OrderResponses
+
+        Must NEVER raise. Must NEVER skip a position. If a single exit
+        fails, retry once, then log the failure and continue to the next.
+
+        Called by:
+          - Dashboard kill-switch button
+          - Max daily loss circuit breaker
+          - Manual API call: POST /api/broker/kill
+        """
+        ...
+
+    # ── Convenience ───────────────────────────────────────────────────
+
+    def buy(self, symbol: str, quantity: int, price: float = 0.0,
+            order_type: OrderType = OrderType.MARKET, tag: str = "") -> OrderResponse:
+        """Convenience: place a BUY order."""
+        return self.place_order(OrderRequest(
+            symbol=symbol, side=OrderSide.BUY, quantity=quantity,
+            price=price, order_type=order_type, tag=tag,
+        ))
+
+    def sell(self, symbol: str, quantity: int, price: float = 0.0,
+             order_type: OrderType = OrderType.MARKET, tag: str = "") -> OrderResponse:
+        """Convenience: place a SELL order."""
+        return self.place_order(OrderRequest(
+            symbol=symbol, side=OrderSide.SELL, quantity=quantity,
+            price=price, order_type=order_type, tag=tag,
+        ))
+
+    def place_sl_order(self, symbol: str, quantity: int,
+                       trigger_price: float, tag: str = "") -> OrderResponse:
+        """Convenience: place a stop-loss market order."""
+        return self.place_order(OrderRequest(
+            symbol=symbol, side=OrderSide.SELL, quantity=quantity,
+            order_type=OrderType.SL_MARKET, trigger_price=trigger_price, tag=tag,
+        ))

--- a/broker/order_manager.py
+++ b/broker/order_manager.py
@@ -1,0 +1,496 @@
+"""
+Order Manager
+─────────────
+Bridges the signal pipeline (scan_market) to the broker adapter.
+
+Responsibilities:
+  - Receives trade suggestions from the scanner
+  - Applies safety checks (max daily loss, concurrent position limit, cooldowns)
+  - Delegates order placement to the active BrokerAdapter
+  - Tracks open orders, manages SL orders, handles exits
+  - Provides a unified interface for the dashboard
+
+The OrderManager does NOT decide WHEN to trade — that's the scanner's job.
+It decides WHETHER to execute (safety), HOW to execute (broker API), and
+tracks WHAT happened (position state).
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, date
+from typing import Optional
+
+from broker.base_adapter import (
+    BrokerAdapter,
+    OrderResponse,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Position,
+)
+from broker.paper_adapter import PaperAdapter
+from broker.zerodha_adapter import ZerodhaAdapter
+from utils.logger import get_logger
+
+logger = get_logger("order_manager")
+
+
+@dataclass
+class ManagedPosition:
+    """Internal position tracking with our signal metadata."""
+    order_id: str
+    symbol: str
+    direction: str                     # "CALL" or "PUT"
+    strategy: str
+    entry_time: datetime
+    entry_price: float
+    quantity: int
+    sl_price: float
+    target_price: float
+    sl_order_id: Optional[str] = None  # broker's SL order ID
+    current_price: float = 0.0
+    pnl: float = 0.0
+    status: str = "OPEN"               # OPEN, CLOSED
+    exit_time: Optional[datetime] = None
+    exit_price: float = 0.0
+    exit_reason: str = ""
+    final_score: float = 0.0
+    ml_prob: float = 0.0
+    journey: list = field(default_factory=list)
+
+
+class OrderManager:
+    """
+    Central execution coordinator.
+
+    Config via env vars:
+      TRADE_MODE           — "paper" (default) or "zerodha"
+      MAX_DAILY_LOSS       — max cumulative loss before auto-stop (default: -5000)
+      MAX_CONCURRENT_POSITIONS — max open positions at once (default: 1)
+      ORDER_CONFIRMATION   — "auto" (default) or "manual" (requires dashboard click)
+    """
+
+    def __init__(self):
+        self._mode = os.getenv("TRADE_MODE", "paper").lower()
+        self._max_daily_loss = float(os.getenv("MAX_DAILY_LOSS", "-5000"))
+        self._max_concurrent = int(os.getenv("MAX_CONCURRENT_POSITIONS", "1"))
+        self._confirmation_mode = os.getenv("ORDER_CONFIRMATION", "auto").lower()
+
+        # Initialize the appropriate adapter
+        if self._mode == "zerodha":
+            self._adapter: BrokerAdapter = ZerodhaAdapter()
+        else:
+            self._adapter: BrokerAdapter = PaperAdapter()
+
+        # State
+        self._positions: list[ManagedPosition] = []
+        self._daily_pnl: float = 0.0
+        self._trade_count: int = 0
+        self._halted: bool = False      # set by kill switch or max loss
+        self._halt_reason: str = ""
+        self._pending_signals: list[dict] = []  # for manual confirmation mode
+        self._lock = threading.Lock()
+
+        logger.info(f"OrderManager initialized: mode={self._mode}, "
+                    f"max_loss=₹{self._max_daily_loss}, max_concurrent={self._max_concurrent}, "
+                    f"confirmation={self._confirmation_mode}")
+
+    # ── Properties ────────────────────────────────────────────────────
+
+    @property
+    def adapter(self) -> BrokerAdapter:
+        return self._adapter
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def is_halted(self) -> bool:
+        return self._halted
+
+    @property
+    def halt_reason(self) -> str:
+        return self._halt_reason
+
+    @property
+    def daily_pnl(self) -> float:
+        return self._daily_pnl
+
+    @property
+    def trade_count(self) -> int:
+        return self._trade_count
+
+    @property
+    def open_positions(self) -> list[ManagedPosition]:
+        return [p for p in self._positions if p.status == "OPEN"]
+
+    @property
+    def closed_positions(self) -> list[ManagedPosition]:
+        return [p for p in self._positions if p.status == "CLOSED"]
+
+    @property
+    def pending_signals(self) -> list[dict]:
+        return list(self._pending_signals)
+
+    # ── Lifecycle ─────────────────────────────────────────────────────
+
+    def connect(self) -> bool:
+        """Authenticate with the broker."""
+        ok = self._adapter.authenticate()
+        if ok:
+            logger.info(f"Connected to {self._adapter.broker_name}")
+        else:
+            logger.error(f"Failed to connect to {self._adapter.broker_name}")
+        return ok
+
+    def reset_daily(self):
+        """Call at start of each trading day to reset counters."""
+        self._daily_pnl = 0.0
+        self._trade_count = 0
+        self._halted = False
+        self._halt_reason = ""
+        self._pending_signals.clear()
+        logger.info("OrderManager: daily reset")
+
+    # ── Entry ─────────────────────────────────────────────────────────
+
+    def submit_signal(self, signal: dict) -> dict:
+        """
+        Receive a trade signal from scan_market and decide what to do.
+
+        signal dict must contain:
+          symbol, direction, strategy, entry_premium, sl_price, target_price,
+          lots, final_score, ml_prob, expiry, index_price
+
+        Returns dict with:
+          action: "executed" | "queued" | "rejected"
+          reason: human-readable explanation
+          order_id: (if executed)
+        """
+        with self._lock:
+            # ── Safety checks ─────────────────────────────────────────
+
+            # 1. Halted?
+            if self._halted:
+                return {"action": "rejected", "reason": f"Trading halted: {self._halt_reason}"}
+
+            # 2. Max daily loss?
+            if self._daily_pnl <= self._max_daily_loss:
+                self._halted = True
+                self._halt_reason = f"Max daily loss breached (₹{self._daily_pnl:,.0f})"
+                logger.warning(f"HALT: {self._halt_reason}")
+                return {"action": "rejected", "reason": self._halt_reason}
+
+            # 3. Concurrent position limit?
+            open_count = len(self.open_positions)
+            if open_count >= self._max_concurrent:
+                return {
+                    "action": "rejected",
+                    "reason": f"Max concurrent positions ({self._max_concurrent}) reached"
+                }
+
+            # 4. Same-direction duplicate?
+            for pos in self.open_positions:
+                if pos.direction == signal.get("direction"):
+                    return {
+                        "action": "rejected",
+                        "reason": f"Already have an open {pos.direction} position ({pos.symbol})"
+                    }
+
+            # 5. Manual confirmation mode?
+            if self._confirmation_mode == "manual":
+                self._pending_signals.append({
+                    **signal,
+                    "received_at": datetime.now().isoformat(),
+                })
+                logger.info(f"Signal QUEUED for manual confirmation: {signal.get('symbol')} "
+                           f"{signal.get('direction')} {signal.get('strategy')}")
+                return {"action": "queued", "reason": "Waiting for manual confirmation on dashboard"}
+
+            # ── Execute ───────────────────────────────────────────────
+            return self._execute_entry(signal)
+
+    def confirm_signal(self, index: int) -> dict:
+        """
+        Confirm a pending signal (manual mode). Called from dashboard.
+        """
+        with self._lock:
+            if index < 0 or index >= len(self._pending_signals):
+                return {"action": "rejected", "reason": "Invalid signal index"}
+            signal = self._pending_signals.pop(index)
+            return self._execute_entry(signal)
+
+    def reject_signal(self, index: int) -> dict:
+        """Reject a pending signal (manual mode)."""
+        with self._lock:
+            if index < 0 or index >= len(self._pending_signals):
+                return {"action": "rejected", "reason": "Invalid signal index"}
+            signal = self._pending_signals.pop(index)
+            logger.info(f"Signal REJECTED by user: {signal.get('symbol')}")
+            return {"action": "rejected", "reason": "Rejected by user"}
+
+    def _execute_entry(self, signal: dict) -> dict:
+        """Place the actual entry order via the adapter."""
+        symbol = signal["symbol"]
+        quantity = signal.get("lots", 65)
+        entry_premium = signal.get("entry_premium", 0)
+
+        resp = self._adapter.buy(
+            symbol=symbol,
+            quantity=quantity,
+            price=entry_premium,
+            tag=signal.get("strategy", "")[:20],
+        )
+
+        if resp.status in (OrderStatus.COMPLETE, OrderStatus.OPEN):
+            fill_price = resp.average_price if resp.average_price > 0 else entry_premium
+            pos = ManagedPosition(
+                order_id=resp.order_id,
+                symbol=symbol,
+                direction=signal.get("direction", ""),
+                strategy=signal.get("strategy", ""),
+                entry_time=datetime.now(),
+                entry_price=fill_price,
+                quantity=quantity,
+                sl_price=signal.get("sl_price", fill_price * 0.85),
+                target_price=signal.get("target_price", fill_price * 1.50),
+                final_score=signal.get("final_score", 0),
+                ml_prob=signal.get("ml_prob", 0),
+            )
+            self._positions.append(pos)
+            self._trade_count += 1
+
+            logger.info(
+                f"ENTRY: {signal.get('direction')} {symbol} ×{quantity} @ ₹{fill_price:.2f} "
+                f"[{signal.get('strategy')}] score={signal.get('final_score', 0):.2f} "
+                f"→ {resp.order_id}"
+            )
+
+            return {
+                "action": "executed",
+                "reason": f"Order placed: {resp.order_id}",
+                "order_id": resp.order_id,
+                "fill_price": fill_price,
+            }
+        else:
+            logger.warning(f"ENTRY FAILED: {symbol} — {resp.message}")
+            return {"action": "rejected", "reason": f"Order failed: {resp.message}"}
+
+    # ── Exit ──────────────────────────────────────────────────────────
+
+    def exit_position(self, order_id: str, price: float = 0, reason: str = "MANUAL") -> dict:
+        """Exit a specific position by its order_id."""
+        with self._lock:
+            pos = next((p for p in self._positions if p.order_id == order_id and p.status == "OPEN"), None)
+            if not pos:
+                return {"action": "rejected", "reason": f"No open position with ID {order_id}"}
+
+            resp = self._adapter.sell(
+                symbol=pos.symbol,
+                quantity=pos.quantity,
+                price=price,
+                tag=reason[:20],
+            )
+
+            if resp.status in (OrderStatus.COMPLETE, OrderStatus.OPEN):
+                fill = resp.average_price if resp.average_price > 0 else price
+                pnl = (fill - pos.entry_price) * pos.quantity
+                pos.status = "CLOSED"
+                pos.exit_time = datetime.now()
+                pos.exit_price = fill
+                pos.exit_reason = reason
+                pos.pnl = pnl
+                self._daily_pnl += pnl
+
+                logger.info(
+                    f"EXIT: {pos.symbol} ×{pos.quantity} @ ₹{fill:.2f} "
+                    f"P&L=₹{pnl:+,.0f} [{reason}]"
+                )
+
+                # Check max daily loss after exit
+                if self._daily_pnl <= self._max_daily_loss:
+                    self._halted = True
+                    self._halt_reason = f"Max daily loss breached (₹{self._daily_pnl:,.0f})"
+                    logger.warning(f"HALT: {self._halt_reason}")
+
+                return {"action": "executed", "pnl": pnl, "order_id": resp.order_id}
+            else:
+                logger.error(f"EXIT FAILED: {pos.symbol} — {resp.message}")
+                return {"action": "rejected", "reason": resp.message}
+
+    # ── SL Management ─────────────────────────────────────────────────
+
+    def update_sl(self, order_id: str, new_sl: float):
+        """Update the SL price for a managed position."""
+        for pos in self._positions:
+            if pos.order_id == order_id and pos.status == "OPEN":
+                old_sl = pos.sl_price
+                if new_sl > old_sl:
+                    pos.sl_price = new_sl
+                    # If there's a live SL order on the broker, modify it
+                    if pos.sl_order_id and self._mode != "paper":
+                        self._adapter.modify_order(
+                            pos.sl_order_id,
+                            trigger_price=new_sl,
+                        )
+                    logger.debug(f"SL updated: {pos.symbol} ₹{old_sl:.2f} → ₹{new_sl:.2f}")
+                break
+
+    def check_sl_target(self, symbol: str, current_price: float):
+        """Check if any open position has hit SL or target. Called by tick monitor."""
+        with self._lock:
+            for pos in self._positions:
+                if pos.symbol != symbol or pos.status != "OPEN":
+                    continue
+                pos.current_price = current_price
+                pos.pnl = (current_price - pos.entry_price) * pos.quantity
+
+                if current_price <= pos.sl_price:
+                    self.exit_position(pos.order_id, price=current_price, reason="SL_HIT")
+                elif current_price >= pos.target_price:
+                    self.exit_position(pos.order_id, price=current_price, reason="TARGET_HIT")
+
+    # ── Safety ────────────────────────────────────────────────────────
+
+    def kill_switch(self) -> dict:
+        """
+        EMERGENCY: Close all positions, cancel all orders, halt trading.
+        """
+        with self._lock:
+            self._halted = True
+            self._halt_reason = "KILL SWITCH activated"
+            logger.warning("=" * 50)
+            logger.warning("  KILL SWITCH ACTIVATED")
+            logger.warning("=" * 50)
+
+            # Close managed positions
+            results = []
+            for pos in self._positions:
+                if pos.status == "OPEN":
+                    result = self.exit_position(pos.order_id, price=pos.current_price, reason="KILL_SWITCH")
+                    results.append(result)
+
+            # Also trigger adapter's own kill switch (catches anything we missed)
+            adapter_results = self._adapter.kill_switch()
+
+            return {
+                "halted": True,
+                "positions_closed": len(results),
+                "adapter_exits": len(adapter_results),
+                "daily_pnl": self._daily_pnl,
+            }
+
+    def resume(self) -> dict:
+        """Resume trading after a halt (manual action)."""
+        with self._lock:
+            self._halted = False
+            self._halt_reason = ""
+            logger.info("Trading RESUMED")
+            return {"halted": False}
+
+    # ── Reconciliation ────────────────────────────────────────────────
+
+    def reconcile(self) -> dict:
+        """
+        Compare our internal state vs the broker's actual positions.
+        Returns discrepancies for manual review.
+        """
+        broker_positions = self._adapter.get_positions()
+        our_open = {p.symbol: p for p in self.open_positions}
+        broker_open = {p.symbol: p for p in broker_positions}
+
+        discrepancies = []
+        # Positions we think are open but broker doesn't have
+        for sym, pos in our_open.items():
+            if sym not in broker_open:
+                discrepancies.append({
+                    "type": "PHANTOM",
+                    "symbol": sym,
+                    "our_qty": pos.quantity,
+                    "broker_qty": 0,
+                    "message": f"We think {sym} is open but broker has no position",
+                })
+
+        # Positions broker has but we don't track
+        for sym, bpos in broker_open.items():
+            if sym not in our_open:
+                discrepancies.append({
+                    "type": "ORPHAN",
+                    "symbol": sym,
+                    "our_qty": 0,
+                    "broker_qty": bpos.quantity,
+                    "message": f"Broker has {sym} ×{bpos.quantity} but we don't track it",
+                })
+
+        # Quantity mismatches
+        for sym in set(our_open) & set(broker_open):
+            if our_open[sym].quantity != broker_open[sym].quantity:
+                discrepancies.append({
+                    "type": "QTY_MISMATCH",
+                    "symbol": sym,
+                    "our_qty": our_open[sym].quantity,
+                    "broker_qty": broker_open[sym].quantity,
+                    "message": f"{sym}: we have ×{our_open[sym].quantity}, broker has ×{broker_open[sym].quantity}",
+                })
+
+        if discrepancies:
+            logger.warning(f"RECONCILIATION: {len(discrepancies)} discrepancy(ies)")
+            for d in discrepancies:
+                logger.warning(f"  {d['type']}: {d['message']}")
+        else:
+            logger.debug("Reconciliation: all positions match")
+
+        return {"discrepancies": discrepancies, "our_open": len(our_open), "broker_open": len(broker_open)}
+
+    # ── State for dashboard ───────────────────────────────────────────
+
+    def to_dict(self) -> dict:
+        """Return full state for the dashboard API."""
+        return {
+            "mode": self._mode,
+            "broker": self._adapter.broker_name,
+            "connected": self._adapter.is_connected,
+            "halted": self._halted,
+            "halt_reason": self._halt_reason,
+            "daily_pnl": round(self._daily_pnl, 2),
+            "trade_count": self._trade_count,
+            "max_daily_loss": self._max_daily_loss,
+            "max_concurrent": self._max_concurrent,
+            "confirmation_mode": self._confirmation_mode,
+            "open_positions": [
+                {
+                    "order_id": p.order_id,
+                    "symbol": p.symbol,
+                    "direction": p.direction,
+                    "strategy": p.strategy,
+                    "entry_time": p.entry_time.isoformat(),
+                    "entry_price": p.entry_price,
+                    "quantity": p.quantity,
+                    "sl_price": p.sl_price,
+                    "target_price": p.target_price,
+                    "current_price": p.current_price,
+                    "pnl": round(p.pnl, 2),
+                    "final_score": p.final_score,
+                }
+                for p in self.open_positions
+            ],
+            "closed_positions": [
+                {
+                    "order_id": p.order_id,
+                    "symbol": p.symbol,
+                    "direction": p.direction,
+                    "strategy": p.strategy,
+                    "entry_price": p.entry_price,
+                    "exit_price": p.exit_price,
+                    "pnl": round(p.pnl, 2),
+                    "exit_reason": p.exit_reason,
+                }
+                for p in self.closed_positions
+            ],
+            "pending_signals": self._pending_signals,
+        }

--- a/broker/paper_adapter.py
+++ b/broker/paper_adapter.py
@@ -1,0 +1,183 @@
+"""
+Paper Trading Adapter
+─────────────────────
+Implements BrokerAdapter for simulated (paper) trading. This is the default
+mode and maintains backward compatibility with the existing paper_positions
+system in backend/app.py.
+
+No real money is touched. Orders "fill" instantly at the requested price.
+Positions are tracked in-memory and persisted to the JSONL trade log.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from broker.base_adapter import (
+    BrokerAdapter,
+    OrderRequest,
+    OrderResponse,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Position,
+)
+from utils.logger import get_logger
+
+logger = get_logger("paper_adapter")
+
+
+class PaperAdapter(BrokerAdapter):
+    """
+    Simulated broker that fills orders instantly at the requested price.
+
+    Positions are tracked in-memory. The OrderManager layer handles
+    persistence to the JSONL trade log and the dashboard state.
+    """
+
+    def __init__(self):
+        self._authenticated = False
+        self._positions: dict[str, Position] = {}   # order_id → Position
+        self._orders: list[OrderResponse] = []       # today's order history
+        self._sl_orders: dict[str, OrderRequest] = {}  # order_id → pending SL
+
+    # ── Authentication ────────────────────────────────────────────────
+
+    def authenticate(self) -> bool:
+        self._authenticated = True
+        logger.info("Paper adapter authenticated (simulated)")
+        return True
+
+    @property
+    def is_connected(self) -> bool:
+        return self._authenticated
+
+    @property
+    def broker_name(self) -> str:
+        return "Paper"
+
+    # ── Order Placement ───────────────────────────────────────────────
+
+    def place_order(self, request: OrderRequest) -> OrderResponse:
+        order_id = f"PAPER-{uuid.uuid4().hex[:12]}"
+        now = datetime.now()
+
+        # Paper orders fill instantly at the requested price (or last known)
+        fill_price = request.price if request.price > 0 else 0.0
+
+        response = OrderResponse(
+            order_id=order_id,
+            status=OrderStatus.COMPLETE,
+            filled_quantity=request.quantity,
+            average_price=fill_price,
+            message=f"Paper {request.side.value} filled at ₹{fill_price:.2f}",
+            timestamp=now,
+            raw={"symbol": request.symbol, "side": request.side.value, "tag": request.tag},
+        )
+        self._orders.append(response)
+
+        # Track position
+        if request.side == OrderSide.BUY:
+            self._positions[order_id] = Position(
+                symbol=request.symbol,
+                exchange=request.exchange,
+                quantity=request.quantity,
+                average_price=fill_price,
+                last_price=fill_price,
+                pnl=0.0,
+                product=request.product,
+                order_id=order_id,
+            )
+            logger.info(f"Paper BUY: {request.symbol} ×{request.quantity} @ ₹{fill_price:.2f} [{order_id}]")
+        elif request.side == OrderSide.SELL:
+            # Find the matching position and close it
+            closed = False
+            for pid, pos in list(self._positions.items()):
+                if pos.symbol == request.symbol and pos.quantity > 0:
+                    pnl = (fill_price - pos.average_price) * min(request.quantity, pos.quantity)
+                    pos.quantity -= request.quantity
+                    pos.pnl += pnl
+                    if pos.quantity <= 0:
+                        del self._positions[pid]
+                    closed = True
+                    logger.info(
+                        f"Paper SELL: {request.symbol} ×{request.quantity} @ ₹{fill_price:.2f} "
+                        f"P&L=₹{pnl:+,.0f} [{order_id}]"
+                    )
+                    break
+            if not closed:
+                logger.warning(f"Paper SELL: no open position found for {request.symbol}")
+
+        return response
+
+    def modify_order(
+        self,
+        order_id: str,
+        quantity: Optional[int] = None,
+        price: Optional[float] = None,
+        trigger_price: Optional[float] = None,
+        order_type: Optional[OrderType] = None,
+    ) -> OrderResponse:
+        # For paper trading, modify just updates the SL trigger in our tracking
+        if order_id in self._sl_orders:
+            if trigger_price is not None:
+                self._sl_orders[order_id].trigger_price = trigger_price
+            logger.info(f"Paper MODIFY: {order_id} trigger→₹{trigger_price:.2f}")
+        return OrderResponse(
+            order_id=order_id,
+            status=OrderStatus.COMPLETE,
+            message="Paper order modified",
+        )
+
+    def cancel_order(self, order_id: str) -> OrderResponse:
+        self._sl_orders.pop(order_id, None)
+        logger.info(f"Paper CANCEL: {order_id}")
+        return OrderResponse(
+            order_id=order_id,
+            status=OrderStatus.CANCELLED,
+            message="Paper order cancelled",
+        )
+
+    # ── Position & Order Queries ──────────────────────────────────────
+
+    def get_positions(self) -> list[Position]:
+        return list(self._positions.values())
+
+    def get_order_status(self, order_id: str) -> OrderResponse:
+        for o in self._orders:
+            if o.order_id == order_id:
+                return o
+        return OrderResponse(order_id=order_id, status=OrderStatus.ERROR, message="Not found")
+
+    def get_orders_today(self) -> list[OrderResponse]:
+        return list(self._orders)
+
+    # ── Safety ────────────────────────────────────────────────────────
+
+    def kill_switch(self) -> list[OrderResponse]:
+        """Close all paper positions at current price (which is average for paper)."""
+        responses = []
+        for pid, pos in list(self._positions.items()):
+            if pos.quantity > 0:
+                resp = self.sell(pos.symbol, pos.quantity, price=pos.last_price, tag="KILL_SWITCH")
+                responses.append(resp)
+        self._sl_orders.clear()
+        logger.warning(f"Paper KILL SWITCH: closed {len(responses)} position(s)")
+        return responses
+
+    # ── Paper-specific helpers ────────────────────────────────────────
+
+    def update_price(self, symbol: str, price: float):
+        """Update the last_price of an open position (called by tick monitor)."""
+        for pos in self._positions.values():
+            if pos.symbol == symbol and pos.quantity > 0:
+                pos.last_price = price
+                pos.pnl = (price - pos.average_price) * pos.quantity
+
+    def reset(self):
+        """Clear all positions and orders (e.g. start of new day)."""
+        self._positions.clear()
+        self._orders.clear()
+        self._sl_orders.clear()

--- a/broker/zerodha_adapter.py
+++ b/broker/zerodha_adapter.py
@@ -1,0 +1,407 @@
+"""
+Zerodha Kite Connect Adapter
+─────────────────────────────
+Real-money execution via Zerodha's Kite Connect API v3.
+
+Authentication flow:
+  1. Server generates a login URL → user opens in browser
+  2. Zerodha redirects back with a `request_token`
+  3. Server exchanges request_token for `access_token` (valid ~6am next day)
+  4. All subsequent API calls use the access_token
+
+Required env vars:
+  ZERODHA_API_KEY       — from https://developers.kite.trade
+  ZERODHA_API_SECRET    — from Kite developer console
+  ZERODHA_ACCESS_TOKEN  — set after OAuth flow (or by /api/broker/auth callback)
+
+Optional:
+  ZERODHA_USER_ID       — for display purposes only
+
+Install:
+  pip install kiteconnect
+
+Docs: https://kite.trade/docs/connect/v3/
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Optional
+
+from broker.base_adapter import (
+    BrokerAdapter,
+    OrderRequest,
+    OrderResponse,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Position,
+    ProductType,
+)
+from utils.logger import get_logger
+
+logger = get_logger("zerodha_adapter")
+
+# Map our OrderType → Kite order_type string
+_ORDER_TYPE_MAP = {
+    OrderType.MARKET: "MARKET",
+    OrderType.LIMIT: "LIMIT",
+    OrderType.SL: "SL",
+    OrderType.SL_MARKET: "SL-M",
+}
+
+# Map our ProductType → Kite product string
+_PRODUCT_MAP = {
+    ProductType.MIS: "MIS",
+    ProductType.NRML: "NRML",
+    ProductType.CNC: "CNC",
+}
+
+
+class ZerodhaAdapter(BrokerAdapter):
+    """
+    Kite Connect v3 broker adapter for real-money trading.
+
+    Usage:
+        adapter = ZerodhaAdapter()
+        if adapter.authenticate():
+            resp = adapter.buy("NIFTY26041323800PE", quantity=25, tag="bearish_momentum")
+    """
+
+    def __init__(self):
+        self._api_key = os.getenv("ZERODHA_API_KEY", "")
+        self._api_secret = os.getenv("ZERODHA_API_SECRET", "")
+        self._access_token = os.getenv("ZERODHA_ACCESS_TOKEN", "")
+        self._user_id = os.getenv("ZERODHA_USER_ID", "")
+        self._kite = None  # kiteconnect.KiteConnect instance
+        self._connected = False
+
+    # ── Authentication ────────────────────────────────────────────────
+
+    def authenticate(self) -> bool:
+        """
+        Authenticate with Kite Connect using the stored access_token.
+
+        If access_token is not set, generate the login URL for the user.
+        The access_token is typically obtained via the OAuth redirect
+        callback at /api/broker/auth/callback.
+        """
+        if not self._api_key:
+            logger.error("ZERODHA_API_KEY not set in .env")
+            return False
+
+        try:
+            from kiteconnect import KiteConnect
+        except ImportError:
+            logger.error("kiteconnect package not installed. Run: pip install kiteconnect")
+            return False
+
+        self._kite = KiteConnect(api_key=self._api_key)
+
+        if self._access_token:
+            self._kite.set_access_token(self._access_token)
+            # Verify the token is valid
+            try:
+                profile = self._kite.profile()
+                self._user_id = profile.get("user_id", self._user_id)
+                self._connected = True
+                logger.info(f"Zerodha authenticated: {self._user_id}")
+                return True
+            except Exception as e:
+                logger.error(f"Zerodha access_token invalid: {e}")
+                self._connected = False
+                return False
+        else:
+            login_url = self._kite.login_url()
+            logger.warning(
+                f"Zerodha: no access_token. Complete OAuth flow:\n"
+                f"  1. Open: {login_url}\n"
+                f"  2. Login and authorize\n"
+                f"  3. Copy the request_token from the redirect URL\n"
+                f"  4. POST it to /api/broker/auth/callback"
+            )
+            return False
+
+    def generate_login_url(self) -> str:
+        """Return the Kite Connect login URL for OAuth2 flow."""
+        if self._kite is None:
+            try:
+                from kiteconnect import KiteConnect
+                self._kite = KiteConnect(api_key=self._api_key)
+            except ImportError:
+                return ""
+        return self._kite.login_url()
+
+    def complete_auth(self, request_token: str) -> bool:
+        """
+        Exchange request_token for access_token (step 3 of OAuth flow).
+
+        Called by /api/broker/auth/callback when user completes login.
+        """
+        if self._kite is None:
+            logger.error("Kite not initialized — call authenticate() first")
+            return False
+        try:
+            data = self._kite.generate_session(request_token, api_secret=self._api_secret)
+            self._access_token = data["access_token"]
+            self._kite.set_access_token(self._access_token)
+            self._user_id = data.get("user_id", "")
+            self._connected = True
+            # Persist token to env so it survives restarts (until tomorrow 6am)
+            os.environ["ZERODHA_ACCESS_TOKEN"] = self._access_token
+            logger.info(f"Zerodha OAuth complete: user={self._user_id}, token set")
+            return True
+        except Exception as e:
+            logger.error(f"Zerodha OAuth failed: {e}")
+            return False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected and self._kite is not None
+
+    @property
+    def broker_name(self) -> str:
+        return "Zerodha"
+
+    # ── Order Placement ───────────────────────────────────────────────
+
+    def place_order(self, request: OrderRequest) -> OrderResponse:
+        if not self.is_connected:
+            return OrderResponse(status=OrderStatus.ERROR, message="Not connected to Zerodha")
+
+        try:
+            kite_params = {
+                "tradingsymbol": request.symbol,
+                "exchange": request.exchange,
+                "transaction_type": request.side.value,
+                "order_type": _ORDER_TYPE_MAP.get(request.order_type, "MARKET"),
+                "product": _PRODUCT_MAP.get(request.product, "MIS"),
+                "quantity": request.quantity,
+                "validity": "DAY",
+                "tag": request.tag[:20] if request.tag else "",  # Kite tag max 20 chars
+            }
+
+            if request.order_type in (OrderType.LIMIT, OrderType.SL):
+                kite_params["price"] = request.price
+            if request.order_type in (OrderType.SL, OrderType.SL_MARKET):
+                kite_params["trigger_price"] = request.trigger_price
+
+            order_id = self._kite.place_order(variety="regular", **kite_params)
+
+            logger.info(
+                f"Zerodha ORDER: {request.side.value} {request.symbol} "
+                f"×{request.quantity} [{request.order_type.value}] → {order_id}"
+            )
+
+            return OrderResponse(
+                order_id=str(order_id),
+                status=OrderStatus.OPEN,
+                filled_quantity=0,  # will be updated by get_order_status
+                message=f"Order placed: {order_id}",
+                timestamp=datetime.now(),
+                raw=kite_params,
+            )
+
+        except Exception as e:
+            error_msg = str(e)
+            logger.error(f"Zerodha order FAILED: {request.symbol} {request.side.value} — {error_msg}")
+
+            # Detect specific rejection reasons
+            status = OrderStatus.REJECTED
+            if "insufficient" in error_msg.lower():
+                status = OrderStatus.REJECTED
+            elif "network" in error_msg.lower() or "timeout" in error_msg.lower():
+                status = OrderStatus.ERROR
+
+            return OrderResponse(
+                status=status,
+                message=error_msg,
+                timestamp=datetime.now(),
+            )
+
+    def modify_order(
+        self,
+        order_id: str,
+        quantity: Optional[int] = None,
+        price: Optional[float] = None,
+        trigger_price: Optional[float] = None,
+        order_type: Optional[OrderType] = None,
+    ) -> OrderResponse:
+        if not self.is_connected:
+            return OrderResponse(status=OrderStatus.ERROR, message="Not connected")
+
+        try:
+            params = {"order_id": order_id, "variety": "regular"}
+            if quantity is not None:
+                params["quantity"] = quantity
+            if price is not None:
+                params["price"] = price
+            if trigger_price is not None:
+                params["trigger_price"] = trigger_price
+            if order_type is not None:
+                params["order_type"] = _ORDER_TYPE_MAP.get(order_type, "MARKET")
+
+            self._kite.modify_order(**params)
+            logger.info(f"Zerodha MODIFY: {order_id} trigger=₹{trigger_price}")
+            return OrderResponse(order_id=order_id, status=OrderStatus.OPEN, message="Modified")
+
+        except Exception as e:
+            logger.error(f"Zerodha MODIFY failed: {order_id} — {e}")
+            return OrderResponse(order_id=order_id, status=OrderStatus.ERROR, message=str(e))
+
+    def cancel_order(self, order_id: str) -> OrderResponse:
+        if not self.is_connected:
+            return OrderResponse(status=OrderStatus.ERROR, message="Not connected")
+
+        try:
+            self._kite.cancel_order(variety="regular", order_id=order_id)
+            logger.info(f"Zerodha CANCEL: {order_id}")
+            return OrderResponse(order_id=order_id, status=OrderStatus.CANCELLED, message="Cancelled")
+        except Exception as e:
+            logger.error(f"Zerodha CANCEL failed: {order_id} — {e}")
+            return OrderResponse(order_id=order_id, status=OrderStatus.ERROR, message=str(e))
+
+    # ── Position & Order Queries ──────────────────────────────────────
+
+    def get_positions(self) -> list[Position]:
+        if not self.is_connected:
+            return []
+
+        try:
+            data = self._kite.positions()
+            positions = []
+            for pos in data.get("net", []):
+                if pos["quantity"] != 0:
+                    positions.append(Position(
+                        symbol=pos["tradingsymbol"],
+                        exchange=pos["exchange"],
+                        quantity=pos["quantity"],
+                        average_price=pos["average_price"],
+                        last_price=pos["last_price"],
+                        pnl=pos["pnl"],
+                        product=ProductType(pos.get("product", "MIS")),
+                    ))
+            return positions
+        except Exception as e:
+            logger.error(f"Zerodha get_positions failed: {e}")
+            return []
+
+    def get_order_status(self, order_id: str) -> OrderResponse:
+        if not self.is_connected:
+            return OrderResponse(status=OrderStatus.ERROR, message="Not connected")
+
+        try:
+            history = self._kite.order_history(order_id)
+            if not history:
+                return OrderResponse(order_id=order_id, status=OrderStatus.ERROR, message="No history")
+
+            latest = history[-1]
+            status_map = {
+                "COMPLETE": OrderStatus.COMPLETE,
+                "REJECTED": OrderStatus.REJECTED,
+                "CANCELLED": OrderStatus.CANCELLED,
+                "OPEN": OrderStatus.OPEN,
+                "PENDING": OrderStatus.PENDING,
+            }
+            return OrderResponse(
+                order_id=order_id,
+                status=status_map.get(latest.get("status", ""), OrderStatus.PENDING),
+                filled_quantity=latest.get("filled_quantity", 0),
+                average_price=latest.get("average_price", 0),
+                message=latest.get("status_message", ""),
+                raw=latest,
+            )
+        except Exception as e:
+            logger.error(f"Zerodha order_status failed: {order_id} — {e}")
+            return OrderResponse(order_id=order_id, status=OrderStatus.ERROR, message=str(e))
+
+    def get_orders_today(self) -> list[OrderResponse]:
+        if not self.is_connected:
+            return []
+
+        try:
+            orders = self._kite.orders()
+            return [
+                OrderResponse(
+                    order_id=str(o["order_id"]),
+                    status=OrderStatus.COMPLETE if o["status"] == "COMPLETE" else OrderStatus.OPEN,
+                    filled_quantity=o.get("filled_quantity", 0),
+                    average_price=o.get("average_price", 0),
+                    message=o.get("status_message", ""),
+                    raw=o,
+                )
+                for o in orders
+            ]
+        except Exception as e:
+            logger.error(f"Zerodha get_orders failed: {e}")
+            return []
+
+    # ── Safety ────────────────────────────────────────────────────────
+
+    def kill_switch(self) -> list[OrderResponse]:
+        """
+        EMERGENCY: Cancel all open orders and close all positions at market.
+
+        This is the nuclear option. Runs even if some individual operations
+        fail — logs errors and continues.
+        """
+        if not self.is_connected:
+            logger.error("KILL SWITCH: not connected to Zerodha!")
+            return []
+
+        responses = []
+
+        # 1. Cancel all pending orders
+        try:
+            orders = self._kite.orders()
+            for o in orders:
+                if o["status"] in ("OPEN", "PENDING", "TRIGGER PENDING"):
+                    try:
+                        self._kite.cancel_order(variety="regular", order_id=o["order_id"])
+                        logger.warning(f"KILL: cancelled order {o['order_id']}")
+                    except Exception as e:
+                        logger.error(f"KILL: cancel {o['order_id']} failed: {e}")
+        except Exception as e:
+            logger.error(f"KILL: fetch orders failed: {e}")
+
+        # 2. Close all open positions
+        try:
+            positions = self.get_positions()
+            for pos in positions:
+                if pos.quantity > 0:
+                    resp = self.sell(
+                        pos.symbol, pos.quantity,
+                        order_type=OrderType.MARKET,
+                        tag="KILL_SWITCH",
+                    )
+                    responses.append(resp)
+                    if resp.status == OrderStatus.ERROR:
+                        # Retry once
+                        logger.warning(f"KILL: retrying {pos.symbol}")
+                        resp2 = self.sell(pos.symbol, pos.quantity, tag="KILL_RETRY")
+                        responses.append(resp2)
+                elif pos.quantity < 0:
+                    resp = self.buy(
+                        pos.symbol, abs(pos.quantity),
+                        order_type=OrderType.MARKET,
+                        tag="KILL_SWITCH",
+                    )
+                    responses.append(resp)
+        except Exception as e:
+            logger.error(f"KILL: close positions failed: {e}")
+
+        logger.warning(f"KILL SWITCH COMPLETE: {len(responses)} exit orders placed")
+        return responses
+
+    # ── Helpers ────────────────────────────────────────────────────────
+
+    def get_margins(self) -> dict:
+        """Return available margin / funds."""
+        if not self.is_connected:
+            return {}
+        try:
+            return self._kite.margins()
+        except Exception as e:
+            logger.error(f"Margins fetch failed: {e}")
+            return {}

--- a/config/settings.py
+++ b/config/settings.py
@@ -144,6 +144,17 @@ WEIGHT_TECHNICAL_STRENGTH = 0.20
 # WEIGHT_STRATEGY_PROB = 0.25  # reserved — strat_prob is used as gate only until models improve
 STRAT_PROB_SCALE = 0.06             # normalize strat_prob raw output to [0,1] when needed
 
+# ── Broker Execution ─────────────────────────────────────────────────────────
+TRADE_MODE = os.getenv("TRADE_MODE", "paper")              # "paper" or "zerodha"
+ORDER_CONFIRMATION = os.getenv("ORDER_CONFIRMATION", "auto")  # "auto" or "manual"
+MAX_DAILY_LOSS = float(os.getenv("MAX_DAILY_LOSS", "-5000"))
+MAX_CONCURRENT_POSITIONS = int(os.getenv("MAX_CONCURRENT_POSITIONS", "1"))
+
+# Zerodha Kite Connect (only needed when TRADE_MODE=zerodha)
+ZERODHA_API_KEY = os.getenv("ZERODHA_API_KEY", "")
+ZERODHA_API_SECRET = os.getenv("ZERODHA_API_SECRET", "")
+ZERODHA_ACCESS_TOKEN = os.getenv("ZERODHA_ACCESS_TOKEN", "")
+
 # ── Logging ───────────────────────────────────────────────────────────────────
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
 

--- a/dashboard/app/charts/page.tsx
+++ b/dashboard/app/charts/page.tsx
@@ -5,6 +5,7 @@ import Sidebar from "@/components/Sidebar";
 import Badge from "@/components/Badge";
 import {
   fetchJSON,
+  SSE_STREAM_URL,
   type Candle,
   type BacktestResults,
   type CandleDateInfo,
@@ -302,6 +303,76 @@ export default function ChartsPage() {
   const [loadingTicks, setLoadingTicks] = useState(false);
 
   const [results, setResults] = useState<BacktestResults>({});
+
+  // ── Live option-chain prices from SSE (today only) ────────────────────
+  // Overlays tick_cache prices onto the chain state every ~1s so the
+  // option chain table updates live without refresh. Only connects the
+  // EventSource when selectedDate === today.
+  // ── Live option chain updates (today only) ───────────────────────────
+  // Two separate mechanisms:
+  //   1. SSE stream → live LTP prices (every ~1s, zero cost — same stream
+  //      that the live page uses, just reads tick_cache from the payload)
+  //   2. Periodic fetchJSON → OI + volume (every 30s via /api/options/chain,
+  //      which is a single DB query — OI/vol don't change faster than that)
+
+  // 1. SSE for live prices
+  useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    if (selectedDate !== today) return;
+
+    const es = new EventSource(SSE_STREAM_URL);
+    es.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data);
+        const cache = data.tick_cache as Record<string, { price: number }> | undefined;
+        if (!cache) return;
+        setChain((prev) => {
+          if (prev.length === 0) return prev;
+          let changed = false;
+          const updated = prev.map((row) => {
+            const live = cache[row.symbol];
+            if (live && live.price > 0 && Math.abs(live.price - row.last_price) > 0.01) {
+              changed = true;
+              return { ...row, last_price: live.price };
+            }
+            return row;
+          });
+          return changed ? updated : prev;
+        });
+      } catch {}
+    };
+    return () => es.close();
+  }, [selectedDate]);
+
+  // 2. Periodic OI + volume refresh (every 30s)
+  useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    if (selectedDate !== today || !selectedExpiry) return;
+
+    const refresh = () => {
+      fetchJSON<OptionChainRow[]>(`/api/options/chain?date=${selectedDate}&expiry=${selectedExpiry}`)
+        .then((rows) => {
+          const freshMap = new Map(rows.map(r => [r.symbol, r]));
+          setChain((prev) => {
+            if (prev.length === 0) return prev;
+            let changed = false;
+            const updated = prev.map((row) => {
+              const fresh = freshMap.get(row.symbol);
+              if (fresh && (fresh.volume !== row.volume || fresh.oi !== row.oi)) {
+                changed = true;
+                return { ...row, volume: fresh.volume, oi: fresh.oi };
+              }
+              return row;
+            });
+            return changed ? updated : prev;
+          });
+        })
+        .catch(() => {});
+    };
+
+    const interval = setInterval(refresh, 30_000);
+    return () => clearInterval(interval);
+  }, [selectedDate, selectedExpiry]);
 
   // Current date info for toggle visibility
   const currentDateInfo = dates.find(d => d.day === selectedDate);

--- a/dashboard/app/live/page.tsx
+++ b/dashboard/app/live/page.tsx
@@ -6,7 +6,7 @@ import Badge from "@/components/Badge";
 import {
   fetchJSON, postJSON,
   enterPaperTrade, exitPaperTrade, getPaperPositions, clearClosedPositions, setAutoTrade,
-  SSE_STREAM_URL,
+  SSE_STREAM_URL, API_BASE,
   type LiveState, type TradeSuggestion, type PaperPosition, type StreamPayload,
 } from "@/lib/api";
 import { RefreshCw, Zap, TrendingUp, TrendingDown, X, Trash2, Radio, Bot, Hand, Activity } from "lucide-react";
@@ -35,6 +35,17 @@ export default function LivePage() {
   const [livePrices, setLivePrices] = useState<Record<string, { price: number; ts: string }>>({});
   const [sseConnected, setSseConnected] = useState(false);
   const esRef = useRef<EventSource | null>(null);
+
+  // Broker execution status
+  const [brokerStatus, setBrokerStatus] = useState<any>(null);
+  const fetchBrokerStatus = () => {
+    fetchJSON<any>("/api/broker/status").then(setBrokerStatus).catch(() => {});
+  };
+  useEffect(() => {
+    fetchBrokerStatus();
+    const iv = setInterval(fetchBrokerStatus, 10_000);
+    return () => clearInterval(iv);
+  }, []);
 
   // SSE connection — single stream replaces all HTTP polling
   useEffect(() => {
@@ -545,6 +556,97 @@ export default function LivePage() {
             </div>
           </div>
         )}
+
+        {/* Broker Execution Status */}
+        <div className="t-panel p-4 mt-4" style={{ borderColor: brokerStatus?.halted ? '#5c1a1a' : '#1a3a1a' }}>
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-[11px] font-semibold uppercase tracking-wider" style={{ color: '#5a6270' }}>
+              Broker Execution
+            </h3>
+            <div className="flex gap-2">
+              <button
+                onClick={() => fetch(`${API_BASE}/api/broker/kill`, { method: "POST" }).then(() => fetchBrokerStatus())}
+                className="px-3 py-1 text-[9px] font-bold uppercase tracking-wider"
+                style={{ background: '#5c1a1a', color: '#ff3e3e', border: '1px solid #ff3e3e' }}
+              >
+                KILL SWITCH
+              </button>
+              {brokerStatus?.halted && (
+                <button
+                  onClick={() => fetch(`${API_BASE}/api/broker/resume`, { method: "POST" }).then(() => fetchBrokerStatus())}
+                  className="px-3 py-1 text-[9px] font-bold uppercase tracking-wider"
+                  style={{ background: '#1a3a1a', color: '#00e87b', border: '1px solid #00e87b' }}
+                >
+                  RESUME
+                </button>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <span className="t-badge" style={{
+              borderColor: brokerStatus?.connected ? '#1a5c3a' : '#5c1a1a',
+              color: brokerStatus?.connected ? '#00e87b' : '#ff3e3e',
+              background: brokerStatus?.connected ? '#0a2a18' : '#2a0a0a',
+            }}>
+              {brokerStatus?.broker ?? "?"} {brokerStatus?.connected ? "CONNECTED" : "DISCONNECTED"}
+            </span>
+            <span className="t-badge" style={{
+              borderColor: '#1a3a5c', color: '#4da6ff', background: '#0a1a2a',
+            }}>
+              MODE: {brokerStatus?.mode?.toUpperCase() ?? "PAPER"}
+            </span>
+            <span className="t-badge" style={{
+              borderColor: brokerStatus?.halted ? '#5c1a1a' : '#2a2a1a',
+              color: brokerStatus?.halted ? '#ff3e3e' : '#5a6270',
+              background: brokerStatus?.halted ? '#2a0a0a' : '#1a1a0a',
+            }}>
+              {brokerStatus?.halted ? `HALTED: ${brokerStatus.halt_reason}` : "ACTIVE"}
+            </span>
+            <span className="t-badge" style={{
+              borderColor: '#2a2a1a',
+              color: (brokerStatus?.daily_pnl ?? 0) >= 0 ? '#00e87b' : '#ff3e3e',
+              background: '#1a1a0a',
+            }}>
+              Broker P&L: ₹{(brokerStatus?.daily_pnl ?? 0).toLocaleString("en-IN")}
+            </span>
+            <span className="t-badge" style={{ borderColor: '#2a2a1a', color: '#5a6270', background: '#1a1a0a' }}>
+              Trades: {brokerStatus?.trade_count ?? 0} | Max Loss: ₹{brokerStatus?.max_daily_loss ?? 0}
+            </span>
+            <span className="t-badge" style={{ borderColor: '#2a2a1a', color: '#5a6270', background: '#1a1a0a' }}>
+              Confirm: {brokerStatus?.confirmation_mode?.toUpperCase() ?? "AUTO"}
+            </span>
+          </div>
+          {(brokerStatus?.pending_signals?.length ?? 0) > 0 && (
+            <div className="mt-3 p-2" style={{ background: '#1a1a0a', border: '1px solid #3a3a1a' }}>
+              <p className="text-[9px] uppercase tracking-wider mb-2" style={{ color: '#e8c300' }}>
+                Pending Signals ({brokerStatus!.pending_signals!.length})
+              </p>
+              {brokerStatus!.pending_signals!.map((sig: any, i: number) => (
+                <div key={i} className="flex items-center justify-between mb-1">
+                  <span className="text-[10px]" style={{ color: '#ccc' }}>
+                    {sig.symbol} {sig.direction} — {sig.strategy} (score {sig.final_score?.toFixed(2)})
+                  </span>
+                  <div className="flex gap-1">
+                    <button
+                      onClick={() => fetch(`${API_BASE}/api/broker/confirm`, { method: "POST", headers: {"Content-Type":"application/json"}, body: JSON.stringify({index: i}) }).then(() => fetchBrokerStatus())}
+                      className="px-2 py-0.5 text-[8px] font-bold"
+                      style={{ background: '#1a5c3a', color: '#00e87b', border: '1px solid #00e87b' }}
+                    >
+                      EXECUTE
+                    </button>
+                    <button
+                      onClick={() => fetch(`${API_BASE}/api/broker/reject`, { method: "POST", headers: {"Content-Type":"application/json"}, body: JSON.stringify({index: i}) }).then(() => fetchBrokerStatus())}
+                      className="px-2 py-0.5 text-[8px] font-bold"
+                      style={{ background: '#5c1a1a', color: '#ff3e3e', border: '1px solid #ff3e3e' }}
+                    >
+                      REJECT
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
 
         {/* Model status — collapsed at bottom */}
         <div className="t-panel p-4 mt-4">

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -1,4 +1,4 @@
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5050";
+export const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:5050";
 
 export const SSE_STREAM_URL = `${API_BASE}/api/stream`;
 

--- a/docs/IMPROVEMENT_ROADMAP.md
+++ b/docs/IMPROVEMENT_ROADMAP.md
@@ -1,0 +1,243 @@
+# AI Trader — Improvement Roadmap
+
+> **Status:** Active. Tier 1 substantially completed 2026-04-08 after
+> data-integrity corrections + entry-gate ports + tick-precise backtest
+> rewrite + option-premium confirmation gate. Current best:
+> **MEDIUM ₹+53,715 / HIGH ₹+62,762** over 18 tick-replay days with max
+> DD ≤ ₹5.5k.
+>
+> **Last backtest:** 2026-04-08 (honest tick-level, ₹+53,715 MEDIUM,
+> 71% WR, R:R 1.37, max DD ₹5,411 on ₹50k capital).
+
+The current system has positive expectancy on tick-level replay but there
+are several known levers that can lift win rate, reduce drawdowns, or open
+up more tradeable setups. Items below are ordered by **expected ROI per
+hour of work**, not by impressiveness.
+
+---
+
+## Priority Tier 1 — High value, low effort
+
+These don't need new training data; they're code changes against the
+existing pipeline. Do these first.
+
+| # | Item | Effort | Estimated impact (MEDIUM profile) | Status |
+|---|---|---|---|---|
+| 1 | **Wire `micro_model` into scoring** (70% macro + 30% micro blend) — model is trained but was unused at inference | 1 hour | +0–8% WR (free win, validate via A/B backtest) | ✅ **Done 2026-04-07** |
+| 2 | **Time-of-day no-entry window** 13:30–14:15 — institutional decision window where most current SL hits cluster | 30 min | -₹2k drawdown, +3% WR | ⬜ Open |
+| 3 | **VIX gate** — reduce lots 50% above India VIX > 16; only `mean_reversion` fires below VIX < 11 | 2 hours | +10% on dollar return | ⬜ Open |
+| 4 | **Pre-event blackout calendar** — static `events.json` with FOMC / CPI / RBI / Budget dates; system holds new entries on those days | 2 hours | Prevents 2–3 catastrophic losses per quarter | ⬜ Open |
+
+### Tier 1a — Emergent items completed 2026-04-08
+
+Unplanned but high-impact fixes that came out of investigating a ₹-7,031
+live loss on 2026-04-08. These were treated as Tier 1 because they fixed
+real correctness bugs, not just performance tuning.
+
+| # | Item | Impact | Status |
+|---|---|---|---|
+| 1a.1 | **NIFTY-I dual-stream bug** — collector was subscribing to NIFTY 50 spot AND NIFTY-I futures and storing both as `symbol='NIFTY-I'`. Ticks alternated between the two (~50pt gap), corrupting every macro feature (RSI/ATR/Bollinger) and silently ruining both training data and live signals. Fixed by dropping the spot subscription in `collect_ticks.py`. | Eliminated systemic signal corruption | ✅ Done 2026-04-08 |
+| 1a.2 | **Expired-options subscription bug** — `get_nearest_expiry()` fell back to `expiries[-1]` from the DB cache, which returned *yesterday's* expiry (already-dead contracts) when called on the next trading day. Live collector was subscribing to dead weeklies every morning. Fixed by fetching the authoritative expiry list from TrueData REST (`getSymbolExpiryList`) with a 1h cache. | No more dead contracts; holiday-shifted weeks handled automatically | ✅ Done 2026-04-08 |
+| 1a.3 | **Tick backfill on startup and during session** — backend had candle backfill but no equivalent for ticks. Session gaps from WebSocket drops persisted until EOD. New `_detect_tick_gaps_today()` + `_backfill_ticks_if_stale()` fill leading/internal/trailing gaps via `getticks` REST every scan cycle. | Closes the 5-day REST window gaps in near-real-time | ✅ Done 2026-04-08 |
+| 1a.4 | **Entry gates ported from backtest to live** — `backend/app.py:scan_market()` had none of the filter gates the backtest enforced. Ported previous-bar direction confirmation + micro-momentum confirmation + option-premium confirmation, all with strategy-aware logic (continuation vs reversal). | Closes the backtest-vs-live correctness gap | ✅ Done 2026-04-08 |
+| 1a.5 | **Option-premium confirmation gate (aka "Fix D")** — new gate reads the last 30 seconds of tick_data for the specific option contract we're about to buy and rejects if premium has been falling >0.8%. Catches "catching a falling knife" entries (exact pattern of 2026-04-08 ₹-7,031 loss). Time-windowed, not tick-count-windowed, so illiquid strikes fail-open. | +₹21,800 MEDIUM vs broken-gate iteration; +₹2,467 vs no-gate baseline | ✅ Done 2026-04-08 |
+| 1a.6 | **Tick-precise backtest exit loop** — `check_exit()` was walking option *minute candles*, not option ticks. Every SL/target/trailing decision was bar-resolution. Rewrote to walk per-tick within each minute when tick data is available; candle-mode fallback for older days. Journey display stays minute-summarized but the exit decisions are now tick-precise. | Backtest matches live reality; no more minute-bar fiction | ✅ Done 2026-04-08 |
+| 1a.7 | **Three-tier intra-trade regime exit** — old code only tightened SL above 0.30% adverse NIFTY move (too loose and too late). Now has three tiers: 0.10% log-warn, 0.20% SL tighten to entry+2%, 0.30% HARD EXIT at current price if underwater. Interval dropped 30s → 10s. | Would have exited 2026-04-08 ₹-7k trade ~20 min earlier with a ₹~5k smaller loss | ✅ Done 2026-04-08 |
+| 1a.8 | **Strategy-aware gate application** — previous-bar and micro-momentum gates both apply to continuation strategies only (`vwap_momentum_breakout`). Reversal strategies (`bearish_momentum`, `mean_reversion`) skip them because a reversal signal *should* fire against recent momentum by design. | Recovered 8 valid reversal trades that were being wrongly filtered | ✅ Done 2026-04-08 |
+
+**Net backtest impact of Tier 1a:** MEDIUM went from ₹+51,248 (previous
+best, without any of these fixes) to ₹+53,715 (+5%) with healthier
+strategy mix and tighter drawdown. HIGH jumped from ₹+56,778 to ₹+62,762
+(+10.5%). Crucially, the system now catches the *exact* live failure
+mode from 2026-04-08 that prompted these fixes.
+
+---
+
+## Priority Tier 2 — Higher effort, meaningful payoff
+
+| # | Item | Effort | Estimated impact | Status |
+|---|---|---|---|---|
+| 5 | **Multi-symbol expansion** — add BANKNIFTY (and possibly FINNIFTY) as a second underlying. Same pipeline, ~2× signal count. | 2 days | 1.5–2× total trade count if strategies generalise | 🟡 **Data collection done** (Plan D, 2026-04-07). Modelling deferred until NIFTY system shows consistent live profit. See "Symbol Budget & Plan D" below. |
+| 6 | **Gemma 3 / local LLM news sentiment** → populate the existing-but-empty `news_boost` field in scoring | 1 week | +2–3% WR on news-driven days | ⬜ Open |
+| 7 | **Order-flow microstructure features (tier 2)** — top-of-book changes, volume-weighted bid/ask delta, level-2 imbalance (needs deeper TrueData feed) | 1–2 weeks | +5% WR (estimate; very signal-dependent) | ⬜ Open |
+
+---
+
+## Priority Tier 3 — Data-hungry, defer until enough samples
+
+These need more training data than we currently have (~50 outcome-labelled
+trades). Don't build them now — they'll just overfit to noise.
+
+| # | Item | Effort | Data needed | Estimated impact |
+|---|---|---|---|---|
+| 8 | **Day-of-week strategy models** — separate `bearish_momentum_TUE.pkl`, `_WED.pkl`, etc. Captures expiry-day theta patterns and new-contract-day volatility. | 1 day code, **6 weeks data wait** | ~30 trades per weekday (≈10 weeks of trading) | +5–10% WR |
+| 9 | **Sequence model (GRU / TCN)** over last 30 candles, replacing the per-bar XGBoost. Learns temporal patterns the current model can't. | 2 weeks code, **3 months data wait** | 600+ outcome-labelled trades | +3–5% AUC, +5% WR |
+| 10 | **RL entry agent** — currently RL only optimises exits. An entry-side RL policy could learn signal-skip rules no fixed gate captures. | 2–3 weeks | 200+ outcome-labelled trades | Highly variable; could be transformative or marginal |
+
+---
+
+## What NOT to build (and why)
+
+- **LLM as price predictor** — LLMs (Gemma, Llama, Claude) have no native
+  time-series reasoning. XGBoost is *strictly better* at structured numeric
+  prediction. Use LLMs for unstructured inputs only (news, journaling).
+- **Yet another candle-based feature** — diminishing returns. The macro
+  feature set is already 50 columns and the model's CV AUC plateau is the
+  *data*, not the model capacity.
+- **Looser thresholds to "trade more"** — we tried this on 2026-04-07 and
+  it produced 10 trades / 0 wins / ₹-8,619. The strict 0.70 floor is an
+  accidental safety filter; keep it.
+
+---
+
+## Realistic 6-month outlook
+
+**Current (2026-04-08, post-Tier-1a, tick-precise):**
+- MEDIUM: ₹+53,715 / 49 trades / 71% WR / R:R 1.37 / max DD ₹-5,411
+- HIGH:   ₹+62,762 / 52 trades / 77% WR / R:R 1.12 / max DD ₹-4,954
+- ~₹3,000/day average on MEDIUM across 18 trading days
+
+Per-day average is ~15% higher than last week's baseline and the system
+now has real intra-trade reversal protection. Ship this version to live,
+monitor for 5 consecutive profitable days, then move to Tier 1 items
+2/3/4 (time-of-day, VIX, event blackout).
+
+**After Tier 1 #2–4 complete:** ₹+3.5–4k/day, WR edging to 75%, max DD ₹3k
+**After Tier 2 (#5 BANKNIFTY + #6 news):** ₹+5k/day if BANKNIFTY generalises
+
+Anything beyond ~₹5k/day on this capital stack almost certainly requires
+broker integration with real fills + slippage feedback. Simulation alone
+cannot get us there.
+
+---
+
+## Symbol Budget & Plan D — Multi-Symbol Data Collection
+
+**Constraint:** Current TrueData subscription = 50 live websocket symbols.
+NIFTY alone uses 16 (spot + futures + ATM±3 = 14 options), and the dynamic
+ATM-walk re-subscription on trending days can add 14–28 more.
+
+### Considered plans
+
+| Plan | Live slots | Tick fidelity for new symbols | Verdict |
+|---|---|---|---|
+| A. Futures+spot only for new symbols | 20 | None — REST only | Safe but no live ticks |
+| B. ATM±2 options for new symbols | 36 baseline / 70 worst | Partial | Overflows on trending days |
+| C. ATM±3 options for new symbols | 48 baseline / 76 worst | Full | Overflows even on calm days |
+| **D. ZERO live slots for new symbols, REST EOD only** | **NIFTY's 16, unchanged** | Full via historical REST | ✅ **Chosen** |
+
+### Plan D — what was implemented (2026-04-07)
+
+1. **`scripts/seed_other_symbols.py`** — one-shot 6-month historical seed
+   - 6mo of 1-min candles for spot + futures of BANKNIFTY, FINNIFTY
+   - Last 5 trading days of option ticks + 1-min candles for ATM±3 strikes
+   - For each historical day, ATM is computed from THAT day's futures close
+     (not today's), so the option strikes always reflect the actual
+     at-the-money window for that session.
+
+2. **`scripts/eod_collect_other_symbols.py`** — daily idempotent EOD runner
+   - Run after market close every weekday
+   - Detects gaps in last N days for spot + futures candles, futures ticks,
+     and per-strike option candles + ticks
+   - Only fetches what's missing (idempotent, safe to re-run)
+   - `--dry-run` reports gaps without fetching
+   - `--also-nifty` adds a safety backfill for NIFTY-I gaps
+
+3. **`scripts/backup_data.py`** — daily snapshot to `~/Dev/Backups/ai-trader/` + Dropbox
+   - DB tables via `psql COPY ... TO STDOUT CSV HEADER` (NOT pg_dump -t, which
+     is broken on TimescaleDB hypertables — see comment in the script). The
+     CSVs are restorable to ANY PostgreSQL via plain `\COPY ... FROM STDIN`.
+   - Models stored two ways:
+     - `models/current/` → verbatim copy of `models/saved/`
+     - `models/by_train_date/YYYY-MM-DD/` → mtime-bucketed `.pkl` files for
+       easy "what model was active on date X" rollback
+   - `backtest_results/`, `config/` copied verbatim
+   - **Integrity verification**: before each new snapshot, runs `gunzip -t`
+     on every `.gz` in the previous snapshot to catch silent corruption
+   - **Off-machine mirror** via `--extra-dest` (repeatable): rsync's the
+     local snapshot to additional destinations like `~/Dropbox/...`. Skipped
+     silently if the parent doesn't exist (so an unmounted external drive
+     doesn't fail the run).
+   - `--rotate N` to delete snapshots older than N days from the primary dest
+   - Baseline snapshot size: ~148 MB (tick_data + minute_candles + features_macro
+     + models)
+
+4. **`scripts/restore_from_backup.py`** — single-command restore on a fresh
+   machine. Validates the snapshot, runs schema init (idempotent), restores
+   each table via `gunzip → psql \COPY` in dependency order, then copies
+   models and supporting files back into the project. Supports
+   `--dry-run`, `--tables-only`, `--models-only`, and `--no-schema-init`.
+   `latest` resolves to the most recent date-named subfolder of `--backup-root`.
+
+### Notes from the seed
+
+- **BANKNIFTY data is healthy** — 32 option contracts × 5 days, 17,004 candles
+  and 179,944 ticks with 99.99% bid/ask coverage. Comparable to NIFTY in quality.
+- **FINNIFTY data is much thinner** — 14 contracts, 409 candles, 770 ticks.
+  Many OTM strikes have <10 ticks/day. Liquidity is genuinely poor and this
+  should be considered when (eventually) training models on FINNIFTY.
+- **NIFTY weekly** is the only weekly expiry; **BANKNIFTY and FINNIFTY are
+  monthly only** (NSE discontinued BANKNIFTY weekly options in late 2024).
+
+### When to upgrade to a wider TrueData plan
+
+The "100+ symbol plan" is the right move if/when:
+- NIFTY model proves profitable in live for ≥4 consecutive weeks
+- You're ready to train BANKNIFTY/FINNIFTY signal models
+- You want live tick microstructure features (not just historical) for the
+  new symbols
+
+Until then, Plan D's REST-only collection is sufficient — the historical
+data accumulates daily and is restored next session by EOD runs.
+
+### Recommended cron / launchd schedule
+
+```bash
+# Every weekday at 16:00 IST (after market close)
+0 16 * * 1-5  cd /Users/aaryansinha/Dev/Projects/ai-trader && \
+              .venv/bin/python scripts/eod_collect_other_symbols.py --include-today
+
+# Every weekday at 16:30 IST — daily backup with 30-day rotation + Dropbox mirror
+30 16 * * 1-5 cd /Users/aaryansinha/Dev/Projects/ai-trader && \
+              .venv/bin/python scripts/backup_data.py \
+                --rotate 30 \
+                --extra-dest ~/Dropbox/ai-trader-backups
+```
+
+### Restoring on a fresh machine
+
+```bash
+# 1. Set up project + DB
+git clone <repo> ai-trader && cd ai-trader
+python -m venv .venv && .venv/bin/pip install -r requirements.txt
+brew install postgresql@17 timescaledb && brew services start postgresql@17
+createdb trading
+
+# 2. Set DB_*, TRUEDATA_USER, TRUEDATA_PASSWORD in .env
+
+# 3. Pull a snapshot from Dropbox (any machine logged into the same Dropbox
+#    account already has a synced copy at ~/Dropbox/ai-trader-backups/)
+
+# 4. Restore — `latest` picks the most recent date folder
+.venv/bin/python scripts/restore_from_backup.py latest \
+    --backup-root ~/Dropbox/ai-trader-backups
+```
+
+The restore script:
+- Initializes the schema (idempotent)
+- Restores tables in dependency order (`symbol_master` → bulk data last)
+- Copies `models/current/` → `models/saved/`
+- Copies `backtest_results/` and `config/` back into the project
+- Prompts before overwriting (unless `--dry-run`)
+
+---
+
+## How to use this file
+
+When picking up new work, check Tier 1 first. If a Tier 1 item is blocked,
+move to Tier 2. **Do not start Tier 3 items until the data prerequisite is
+met** — premature training on small samples produces models that are worse
+than no model at all (we've already hit this with `bearish_momentum_model.pkl`).
+
+Update the **Status** column when work is done. Add new ideas at the bottom
+of the relevant tier; re-rank when the priorities shift.


### PR DESCRIPTION
## Summary

- Broker-agnostic execution layer with adapter pattern
- Zerodha Kite Connect v3 implementation (OAuth2 auth, order placement, position tracking, kill switch)
- Paper adapter maintains full backward compatibility
- OrderManager bridges signal pipeline to broker with safety controls
- Dashboard UI: broker status panel, kill switch, manual confirmation mode

## Architecture

```
scan_market() → OrderManager.submit_signal() → BrokerAdapter.buy/sell()
                     ↓                              ↓
              Safety checks:              Paper (simulated) or
              - max daily loss            Zerodha (real money)
              - concurrent limit
              - same-direction dup
              - manual confirmation
```

## Files

| File | Purpose |
|---|---|
| `broker/base_adapter.py` | Abstract interface: authenticate, buy, sell, modify_sl, kill_switch |
| `broker/paper_adapter.py` | Simulated broker (default mode) |
| `broker/zerodha_adapter.py` | Kite Connect v3 with OAuth2 |
| `broker/order_manager.py` | Signal → order bridge with safety controls |
| `backend/app.py` | 10 new `/api/broker/*` endpoints |
| `config/settings.py` | TRADE_MODE, ZERODHA_*, MAX_DAILY_LOSS env vars |
| `dashboard/app/live/page.tsx` | Broker status panel + kill switch UI |

Also includes system fixes from this development cycle (entry gates, tick backfill, trailing stop fix, dual-stream bug, expired options, etc.)

## Test plan

- [x] Paper adapter: buy/sell/kill_switch all tested
- [x] OrderManager: concurrent position limit verified
- [x] Same-direction duplicate rejection verified
- [x] Backend imports cleanly with broker routes
- [x] TypeScript compiles cleanly
- [ ] Zerodha: requires API key + OAuth login (not testable without credentials)
- [ ] Manual confirmation mode: UI renders pending signals with Execute/Reject buttons
- [ ] Kill switch: dashboard button wired to POST /api/broker/kill

🤖 Generated with [Claude Code](https://claude.com/claude-code)