### PR TITLE
[#17] fix: 3 entry-quality gates (loose Gate B + ladder cooldown + mean_reversion trend gate)

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -543,6 +543,13 @@ _TICK_BACKFILL_MIN_INTERVAL = 60.0
 _consecutive_sl_hits: int = 0
 _sl_pause_until: datetime = datetime.min
 
+# Per-(strategy, direction) entry cooldown to prevent ladder entries on the
+# same exhausted move. Apr 28 fired 5 bearish_momentum PUTs within 65 min,
+# 4 of 5 lost. Block subsequent entries of the same (strategy, direction)
+# for STRATEGY_DIRECTION_COOLDOWN_SECS after one fires, regardless of strike.
+STRATEGY_DIRECTION_COOLDOWN_SECS = 900  # 15 minutes
+_last_entry_by_strat_dir: dict[tuple[str, str], datetime] = {}
+
 
 def _detect_tick_gaps_today(min_gap_secs: int = TICK_STALENESS_THRESHOLD_SECS) -> list:
     """
@@ -977,21 +984,20 @@ def scan_market():
                         f"and directional_prob={directional_prob:.3f} < 0.85"
                     )
                     continue
-                # ── Gate B: multi-timeframe RSI divergence (added 2026-04-24)
-                # 4 of 5 live losses on Apr 22-23 entered with rsi<40 (1m
-                # oversold) while rsi_15m>85 (higher-TF extremely stretched
-                # to the upside). The Gate A check missed these because
-                # close had just ticked below ema50. An initial version
-                # used rsi_5m>60 as the higher-TF check but that also
-                # filtered too many real reversals (backtest regressed
-                # ₹81k→₹44k). rsi_15m>80 is a tighter "clearly stretched
-                # higher-TF" signal that still catches all 4 live losses.
+                # ── Gate B: multi-timeframe RSI divergence (added 2026-04-24,
+                # loosened 2026-04-29). Apr 22-23 live losses entered with
+                # rsi_1m<40 + rsi_15m>85. Apr 28 added 2 more near-misses
+                # (rsi_1m=40.9 and 44.1) that Gate B with strict <40 missed.
+                # Loosening to <45 catches those without filtering legitimate
+                # reversals — bearish_momentum PUT into a clearly stretched
+                # higher-TF (r15m>80) is the wrong setup whether r1m is 38
+                # or 44.
                 rsi_1m  = float(latest.get("rsi") or 50.0)
                 rsi_15m = float(latest.get("rsi_15m") or 50.0)
-                if rsi_1m < 40.0 and rsi_15m > 80.0:
+                if rsi_1m < 45.0 and rsi_15m > 80.0:
                     logger.info(
                         f"SKIP bearish_momentum PUT: multi-TF RSI divergence "
-                        f"(rsi_1m={rsi_1m:.1f}<40 rsi_15m={rsi_15m:.1f}>80) — "
+                        f"(rsi_1m={rsi_1m:.1f}<45 rsi_15m={rsi_15m:.1f}>80) — "
                         f"pullback-bottom inside stretched-up higher-TF"
                     )
                     continue
@@ -1003,6 +1009,24 @@ def scan_market():
                 # ML must confirm direction: directional_prob < 0.40 = model actively opposes signal
                 if directional_prob < 0.40:
                     continue
+                # Trend-context gate for mean_reversion PUT (added 2026-04-29
+                # after Apr 29 PUT mean_rev MAE -₹3,433 / final -₹60). PUT
+                # mean_reversion in an established uptrend with stretched
+                # higher-TF (r15m>70) is the same anti-pattern as bearish_
+                # momentum PUT in uptrend — fading the dominant trend.
+                if sig.direction == "PUT":
+                    close_px = float(latest.get("close", 0) or 0)
+                    ema20_v  = float(latest.get("ema20", 0) or 0)
+                    ema50_v  = float(latest.get("ema50", 0) or 0)
+                    rsi_15m  = float(latest.get("rsi_15m") or 50.0)
+                    in_uptrend = (close_px > 0 and ema50_v > 0
+                                  and close_px > ema50_v and ema20_v > ema50_v)
+                    if in_uptrend and rsi_15m > 70.0:
+                        logger.info(
+                            f"SKIP mean_reversion PUT: uptrend+stretched higher-TF "
+                            f"(close={close_px:.2f} ema50={ema50_v:.2f} rsi_15m={rsi_15m:.1f}>70)"
+                        )
+                        continue
                 effective_threshold = max(effective_threshold, 0.80)
             elif sig.strategy == "vwap_momentum_breakout":
                 # Tightened 2026-04-08: was firing on 2-3 bar micro-spikes that reverted
@@ -1022,6 +1046,25 @@ def scan_market():
 
             if final_score < effective_threshold:
                 continue
+
+            # ── Same-(strategy, direction) ladder cooldown (added 2026-04-29) ─
+            # Prevents firing multiple entries on the same exhausted move.
+            # Apr 28 fired 5 bearish_momentum PUTs in 65min, 4 lost. Apr 23
+            # fired 3 bearish_momentum PUTs in 8min, 2 lost. Block subsequent
+            # entries of the same (strategy, direction) for 15 min after one
+            # fires, regardless of strike.
+            sd_key = (sig.strategy, sig.direction)
+            last_sd = _last_entry_by_strat_dir.get(sd_key)
+            if last_sd is not None:
+                age = (datetime.now() - last_sd).total_seconds()
+                if age < STRATEGY_DIRECTION_COOLDOWN_SECS:
+                    remaining = int((STRATEGY_DIRECTION_COOLDOWN_SECS - age) / 60)
+                    logger.info(
+                        f"SKIP {sig.strategy} {sig.direction}: same-strat/dir cooldown "
+                        f"({remaining}min left, last fired {int(age/60)}min ago) — "
+                        f"avoid laddering"
+                    )
+                    continue
 
             # ── Previous-bar direction confirmation (CONTINUATION ONLY) ──────
             # Rejects trades where the previous 1-min bar moved counter to the
@@ -1242,6 +1285,9 @@ def scan_market():
             if len(state["trade_suggestions"]) > 50:
                 state["trade_suggestions"] = state["trade_suggestions"][-50:]
             state["trades_today"] += 1
+
+            # Record this fire for the same-(strategy, direction) ladder cooldown
+            _last_entry_by_strat_dir[(sig.strategy, sig.direction)] = datetime.now()
 
             logger.info(
                 f"TRADE SUGGESTION: {sig.direction} {opt_symbol} | "

--- a/scripts/tick_replay_backtest.py
+++ b/scripts/tick_replay_backtest.py
@@ -734,6 +734,12 @@ def replay_day(
     consecutive_sl_hits = 0
     sl_pause_until_bar = -1  # bar index after which trading resumes
 
+    # Same-(strategy, direction) ladder cooldown (added 2026-04-29). Apr 28
+    # live fired 5 bearish_momentum PUTs in 65min, 4 lost. Block subsequent
+    # entries of the same (strategy, direction) for 15 min after one fires.
+    STRATEGY_DIRECTION_COOLDOWN_BARS = 15  # 15 bars ≈ 15 min on 1m chart
+    last_entry_bar_by_strat_dir: dict[tuple[str, str], int] = {}
+
     # ── Stream minutes ───────────────────────────────────────────────────
     for bar_idx, minute_ts in enumerate(minutes):
         minute_ticks = minute_groups.get_group(minute_ts)
@@ -943,20 +949,18 @@ def replay_day(
                             f"dir_prob={directional_prob:.3f} < 0.85"
                         )
                     continue
-                # ── Gate B: multi-timeframe RSI divergence (added 2026-04-24)
-                # 4 of 5 live Apr 22-23 losses entered with rsi<40 (1m
-                # oversold) while rsi_15m>85 (higher-TF extremely stretched
-                # up). Gate A misses these when close ticks just below
-                # ema50. Initial rsi_5m>60 threshold filtered too many real
-                # reversals; rsi_15m>80 is tight enough to catch only truly
-                # stretched up-days while sparing legitimate reversals.
+                # ── Gate B: multi-timeframe RSI divergence (loosened 2026-04-29)
+                # Apr 28 added 2 near-misses with rsi_1m=40.9 and 44.1 that
+                # the strict <40 threshold missed. Loosened to <45 — entries
+                # against r15m>80 (clearly stretched higher-TF) are wrong
+                # whether r1m is 38 or 44.
                 rsi_1m  = float(latest.get("rsi") or 50.0)
                 rsi_15m = float(latest.get("rsi_15m") or 50.0)
-                if rsi_1m < 40.0 and rsi_15m > 80.0:
+                if rsi_1m < 45.0 and rsi_15m > 80.0:
                     if verbose:
                         print(
                             f"    SKIP  bearish_momentum PUT  multi-TF RSI divergence "
-                            f"(rsi_1m={rsi_1m:.1f}<40 rsi_15m={rsi_15m:.1f}>80)"
+                            f"(rsi_1m={rsi_1m:.1f}<45 rsi_15m={rsi_15m:.1f}>80)"
                         )
                     continue
             elif sig.strategy == "mean_reversion":
@@ -968,6 +972,24 @@ def replay_day(
                 # against the signal — counter-trend entries without ML backing have poor outcomes
                 if directional_prob < 0.40:
                     continue
+                # Trend-context gate for mean_reversion PUT (added 2026-04-29
+                # after Apr 29 PUT mean_rev MAE -₹3,433): same anti-pattern
+                # as bearish_momentum PUT in uptrend — fading the dominant
+                # trend when higher-TF is clearly stretched.
+                if sig.direction == "PUT":
+                    close_px_mr = float(latest.get("close", 0) or 0)
+                    ema20_mr    = float(latest.get("ema20", 0) or 0)
+                    ema50_mr    = float(latest.get("ema50", 0) or 0)
+                    rsi_15m_mr  = float(latest.get("rsi_15m") or 50.0)
+                    in_uptrend_mr = (close_px_mr > 0 and ema50_mr > 0
+                                     and close_px_mr > ema50_mr and ema20_mr > ema50_mr)
+                    if in_uptrend_mr and rsi_15m_mr > 70.0:
+                        if verbose:
+                            print(
+                                f"    SKIP  mean_reversion PUT  uptrend+stretched higher-TF "
+                                f"(close={close_px_mr:.2f} ema50={ema50_mr:.2f} rsi_15m={rsi_15m_mr:.1f}>70)"
+                            )
+                        continue
                 min_score = max(min_score, 0.80)
             elif sig.strategy == "vwap_momentum_breakout":
                 # Tightened 2026-04-08: was firing on 2-3 bar micro-spikes that reverted
@@ -999,6 +1021,17 @@ def replay_day(
                 continue
 
             signals_passed += 1
+
+            # ── Same-(strategy, direction) ladder cooldown (added 2026-04-29) ─
+            sd_key = (sig.strategy, sig.direction)
+            last_bar_sd = last_entry_bar_by_strat_dir.get(sd_key, -10**9)
+            if (bar_idx - last_bar_sd) < STRATEGY_DIRECTION_COOLDOWN_BARS:
+                if verbose:
+                    print(
+                        f"    SKIP  {sig.strategy} {sig.direction}  same-strat/dir cooldown "
+                        f"({bar_idx - last_bar_sd}/{STRATEGY_DIRECTION_COOLDOWN_BARS} bars since last)"
+                    )
+                continue
 
             # ── 9a. Previous-bar direction confirmation (CONTINUATION ONLY) ──
             # Reversal strategies (bearish_momentum, mean_reversion) inherently
@@ -1129,6 +1162,7 @@ def replay_day(
                 rl_agent=rl_agent,
             )
             daily_trades += 1
+            last_entry_bar_by_strat_dir[(sig.strategy, sig.direction)] = bar_idx
 
             if verbose:
                 print(


### PR DESCRIPTION
Closes #17

## Summary
Three gates added after deep analysis of the last 10 live paper trades (Apr 23-29, net -₹120, 7 losses with 5 trades that never went profitable):

1. **Gate B loosened** — `rsi_1m < 45 AND rsi_15m > 80` (was `<40`). Catches Apr 28 near-misses where 1m RSI was 40-44 but 15m RSI was clearly stretched (>92).
2. **Same-(strategy, direction) ladder cooldown** — 15-min lockout. Apr 28 fired 5 bearish_momentum PUTs in 65 min on the same exhausted move; this blocks the 4 marginal followers.
3. **Trend-context gate for `mean_reversion PUT`** — reject when `close>ema50 AND ema20>ema50 AND rsi_15m>70`. Apr 29 PUT mean_reversion in stretched uptrend MFE never positive (-₹284), MAE -₹3,433.

## Validation MEDIUM backtest (33 sessions)
| Metric | Before | After |
|---|---|---|
| P&L | +₹44,120 | **+₹65,296** |
| Trades | 51 | 48 |
| WR | 67% | **71%** |
| RR | 1.60 | **2.44** |

Apr 28 backtest result: 2 trades / 2W / 0L / +₹562 (vs live 5 trades, 1W/4L net +₹1,218).

## Models retrained
Macro 55,677 samples / AUC 0.565. Strategy + RL refreshed on Apr 30 journey data.

## Test plan
- [x] Both files compile
- [x] Backtest clean across 33 sessions
- [ ] Monitor next live session — verify cooldown and mean_rev gate fire when expected
- [ ] Deep-drawdown hard exit deferred (symmetric, gives up real wins; needs separate analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)